### PR TITLE
Handle hexdigits when unescaping uris

### DIFF
--- a/src/serd_internal.h
+++ b/src/serd_internal.h
@@ -294,6 +294,13 @@ is_digit(const uint8_t c)
 	return in_range(c, '0', '9');
 }
 
+/* RFC2234: HEXDIG ::= DIGIT / "A" / "B" / "C" / "D" / "E" / "F" */
+static inline bool
+is_hexdig(const uint8_t c)
+{
+        return is_digit(c) || in_range(c, 'A', 'F');
+}
+
 static inline bool
 is_space(const char c)
 {

--- a/src/uri.c
+++ b/src/uri.c
@@ -78,7 +78,7 @@ serd_file_uri_parse(const uint8_t* uri, uint8_t** hostname)
 			if (*(s + 1) == '%') {
 				serd_chunk_sink("%", 1, &chunk);
 				++s;
-			} else if (is_digit(*(s + 1)) && is_digit(*(s + 2))) {
+			} else if (is_hexdig(*(s + 1)) && is_hexdig(*(s + 2))) {
 				const uint8_t code[3] = { *(s + 1), *(s + 2), 0 };
 				uint32_t num;
 				sscanf((const char*)code, "%X", &num);

--- a/tests/serd_test.c
+++ b/tests/serd_test.c
@@ -373,7 +373,7 @@ main(void)
 		return failure("bad tolerance of junk escape: `%s'\n", out_path);
 	}
 	free(out_path);
-	out_path = serd_file_uri_parse(USTR("file://host/foo/%0Abar"), NULL);
+	out_path = serd_file_uri_parse(USTR("file://host/foo/%0Xbar"), NULL);
 	if (strcmp((const char*)out_path, "/foo/bar")) {
 		return failure("bad tolerance of junk escape: `%s'\n", out_path);
 	}


### PR DESCRIPTION
`serd_node_new_file()` escapes `!is_uri_path_char()` characters to %XX where XX is
a pair of hexdigits. Thus `serd_file_uri_parse()` also has to unescape %XX properly.

This is crucial, if non-ascii unicode chars are in the URI, which is the case when for example somewhere in the session path of an Ardour session a `!(is_digit() || is_alpha())` character occurs.

The introduced `is_hexdig()` function does not tolerate small "a-f" letters as hex digits, because RFC2234 does not mention them as being allowed in a hexdig. 

Topic has been discussed in #ardour with @x42.