### PR TITLE
Fix autowaf gitmodules path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "waflib"]
 	path = waflib
-	url = ../autowaf
+	url = ../autowaf.git


### PR DESCRIPTION
The personal hosting (git.drobilla) doesn't accept path without ".git" ending. Github/gitlab do. However, all 3 do well when ending is used.

Unfortunally, gentoo git-based ebuilds can't use gitmodules patch, because there is no way to split primary and modules fetching. So, such change looks more urgent to submit, that anything else.

P.S. Looks like it is not matter of ".git" suffix, but rather ability to support only one or with optional ext. Github/gitlab allow both with ".git" and without it. As for git.drobilla.org, I compared it with almost similar git.xfce.org, which look like having same engine. Difference is that xfce hosting has not ".git" at the end, but as result, it will not work when this URI ending presents.

P.P.S. This case with autowaf path seems to be way harder. It's clone path has no ".git", thus it is expected to work without it, but it doesn't. Is it bug?..