### PR TITLE
prevent invalid reads when a string literal is unterminated

### DIFF
--- a/src/n3.c
+++ b/src/n3.c
@@ -305,6 +305,11 @@ read_STRING_LITERAL_LONG(SerdReader* reader, SerdNodeFlags* flags, uint8_t q)
 	Ref ref = push_node(reader, SERD_LITERAL, "", 0);
 	while (!reader->status) {
 		const uint8_t c = peek_byte(reader);
+		if (c == '\0') {
+			r_err(reader, SERD_ERR_BAD_SYNTAX,
+			      "unexpected end of file while reading string literal\n");
+			return pop_node(reader, ref);
+		}
 		if (c == '\\') {
 			eat_byte_safe(reader, c);
 			uint32_t code;


### PR DESCRIPTION
I consider this proposed change more of a proof-of-concept fix, as I am not very familiar with the serd codebase. Its main purpose is to illustrate the problem by showing one way of preventing it from happening.

When parsing an unterminated string literal in a turtle/trig/turtle file, serd will perform invalid reads beyond the string buffer end. For example with the following input file:

```
<http://example.com/foo> <http://example.com/comment> """unterminated
```

The output is something as follows:

```
<http://example.com/foo> <http://example.com/comment> "unterminated\n\u0000\u0000 ...repeats a lot... u0000" .
error: invalid2.ttl:2:0: unexpected end of file
```

In the context I am using serd, I am passing a nul-terminated string of the exact size of the input to `serd_reader_read_string`. In this use-case the `read_head` surpasses the length of the string buffer and performs invalid reads.
With serdi, it does not seem to perform invalid reads, instead producing the presumably undesired output of many nul characters.