### PR TITLE
adds support for writing hextuples, fixes #44.

### DIFF
--- a/include/serd/serd.h
+++ b/include/serd/serd.h
@@ -79,6 +79,7 @@ typedef enum {
   SERD_NTRIPLES = 2U, ///< Line-based triples http://www.w3.org/TR/n-triples/
   SERD_NQUADS   = 3U, ///< Line-based quads http://www.w3.org/TR/n-quads/
   SERD_TRIG     = 4U, ///< Terse quads http://www.w3.org/TR/trig/
+  SERD_HEXTUPLES = 5U, ///< ndjson hex tuples https://github.com/ontola/hextuples
 } SerdSyntax;
 
 /// Flags indicating certain string properties relevant to serialisation

--- a/src/writer.c
+++ b/src/writer.c
@@ -145,7 +145,8 @@ write_node(SerdWriter*        writer,
 SERD_NODISCARD static bool
 supports_abbrev(const SerdWriter* writer)
 {
-  return writer->syntax == SERD_TURTLE || writer->syntax == SERD_TRIG || writer->syntax == SERD_HEXTUPLES;
+  return writer->syntax == SERD_TURTLE || writer->syntax == SERD_TRIG ||
+         writer->syntax == SERD_HEXTUPLES;
 }
 
 static SerdStatus
@@ -554,9 +555,9 @@ write_sep(SerdWriter* writer, const Sep sep)
 
   // Write newline or space before separator if necessary
   if (pre_line) {
-	TRY(st, write_newline(writer));
+    TRY(st, write_newline(writer));
   } else if (rule->pre_space_after & (1U << writer->last_sep)) {
-	TRY(st, esink(" ", 1, writer));
+    TRY(st, esink(" ", 1, writer));
   }
 
   // Write actual separator string
@@ -704,37 +705,35 @@ write_uri_node(SerdWriter* const writer,
   if (supports_abbrev(writer)) {
     if (field == FIELD_PREDICATE &&
         !strcmp((const char*)node->buf, NS_RDF "type")) {
-	  if (writer->syntax == SERD_HEXTUPLES) {
-		  return esink("\"a\"", 3, writer);
-	  }
-	  else {
-		  return esink("a", 1, writer);
-	  }
+      if (writer->syntax == SERD_HEXTUPLES) {
+        return esink("\"a\"", 3, writer);
+      } else {
+        return esink("a", 1, writer);
+      }
     }
 
     if (!strcmp((const char*)node->buf, NS_RDF "nil")) {
-	  if (writer->syntax == SERD_HEXTUPLES) {
-		  return esink("null", 4, writer);
-	  }
-	  else {
-		  return esink("()", 2, writer);
-	  }
+      if (writer->syntax == SERD_HEXTUPLES) {
+        return esink("null", 4, writer);
+      } else {
+        return esink("()", 2, writer);
+      }
     }
 
     if (has_scheme && (writer->style & SERD_STYLE_CURIED) &&
         serd_env_qualify(writer->env, node, &prefix, &suffix) &&
         is_name(prefix.buf, prefix.n_bytes) &&
         is_name(suffix.buf, suffix.len)) {
-	  if (writer->syntax == SERD_HEXTUPLES) {
-		  TRY(st, esink("\"", 1, writer));
-	  }
+      if (writer->syntax == SERD_HEXTUPLES) {
+        TRY(st, esink("\"", 1, writer));
+      }
       TRY(st, write_uri_from_node(writer, &prefix));
       TRY(st, esink(":", 1, writer));
       TRY(st, ewrite_uri(writer, suffix.buf, suffix.len));
-	  if (writer->syntax == SERD_HEXTUPLES) {
-		  TRY(st, esink("\"", 1, writer));
-	  }
-	  return st;
+      if (writer->syntax == SERD_HEXTUPLES) {
+        TRY(st, esink("\"", 1, writer));
+      }
+      return st;
     }
   }
 
@@ -748,9 +747,9 @@ write_uri_node(SerdWriter* const writer,
   }
 
   if (writer->syntax == SERD_HEXTUPLES) {
-	  TRY(st, esink("\"", 1, writer));
+    TRY(st, esink("\"", 1, writer));
   } else {
-	  TRY(st, esink("<", 1, writer));
+    TRY(st, esink("<", 1, writer));
   }
 
   if (writer->style & SERD_STYLE_RESOLVED) {
@@ -777,16 +776,15 @@ write_uri_node(SerdWriter* const writer,
   }
 
   if (writer->syntax == SERD_HEXTUPLES) {
-	  /* TRY(st, esink("$CUE", 4, writer)); */
-	  if (field == FIELD_PREDICATE || field == FIELD_SUBJECT ){
-		  return esink("\"", 1, writer);
-	  } else {
-		  TRY(st, esink("\"", 1, writer));
-		  TRY(st, write_sep(writer, SEP_LIST_END));
-		  return st;
-	  }
+    if (field == FIELD_PREDICATE || field == FIELD_SUBJECT) {
+      return esink("\"", 1, writer);
+    } else {
+      TRY(st, esink("\"", 1, writer));
+      TRY(st, write_sep(writer, SEP_LIST_END));
+      return st;
+    }
   } else {
-	  return esink(">", 1, writer);
+    return esink(">", 1, writer);
   }
 }
 
@@ -845,8 +843,8 @@ write_blank(SerdWriter* const        writer,
   }
 
   if (writer->syntax == SERD_HEXTUPLES) {
-	  TRY(st, esink("\"", 1, writer));
-  } 
+    TRY(st, esink("\"", 1, writer));
+  }
 
   TRY(st, esink("_:", 2, writer));
   if (writer->bprefix && !strncmp((const char*)node->buf,
@@ -860,7 +858,7 @@ write_blank(SerdWriter* const        writer,
     TRY(st, esink(node->buf, node->n_bytes, writer));
   }
   if (writer->syntax == SERD_HEXTUPLES) {
-	  TRY(st, esink("\"", 1, writer));
+    TRY(st, esink("\"", 1, writer));
   }
 
   return st;
@@ -984,39 +982,38 @@ serd_writer_write_statement(SerdWriter*        writer,
     }
     TRY(st, esink(" .\n", 3, writer));
     return SERD_SUCCESS;
-  }
-  else if (writer->syntax == SERD_HEXTUPLES) {
+  } else if (writer->syntax == SERD_HEXTUPLES) {
     TRY(st, esink("[", 1, writer));
     TRY(st, write_node(writer, subject, NULL, NULL, FIELD_SUBJECT, flags));
     TRY(st, esink(", ", 2, writer));
     TRY(st, write_node(writer, predicate, NULL, NULL, FIELD_PREDICATE, flags));
     TRY(st, esink(", ", 2, writer));
-	// object
-	TRY(st, esink("\"", 1, writer));
-	TRY(st, write_text(writer, WRITE_STRING, object->buf, object->n_bytes));
-	st = esink("\"", 1, writer);
+    // object
+    TRY(st, esink("\"", 1, writer));
+    TRY(st, write_text(writer, WRITE_STRING, object->buf, object->n_bytes));
+    st = esink("\"", 1, writer);
 
-	TRY(st, esink(", ", 2, writer));
-	//datatype
-	if (datatype && datatype->buf) {
-		st = write_node(writer, datatype, NULL, NULL, FIELD_NONE, flags);
-	} else {
-		TRY(st, esink("\"\"", 2, writer));
-	}
-	TRY(st, esink(", ", 2, writer));
-	// lang
-	TRY(st, esink("\"", 1, writer));
-	if (lang && lang->buf) {
-		st = esink(lang->buf, lang->n_bytes, writer);
-	}
-	TRY(st, esink("\"", 1, writer));
+    TRY(st, esink(", ", 2, writer));
+    // datatype
+    if (datatype && datatype->buf) {
+      TRY(st, write_node(writer, datatype, NULL, NULL, FIELD_NONE, flags));
+    } else {
+      TRY(st, esink("\"\"", 2, writer));
+    }
+    TRY(st, esink(", ", 2, writer));
+    // lang
+    TRY(st, esink("\"", 1, writer));
+    if (lang && lang->buf) {
+      TRY(st, esink(lang->buf, lang->n_bytes, writer));
+    }
+    TRY(st, esink("\"", 1, writer));
 
-	TRY(st, esink(", ", 2, writer));
-	TRY(st, esink("\"", 1, writer));
+    TRY(st, esink(", ", 2, writer));
+    TRY(st, esink("\"", 1, writer));
     if (graph) {
       TRY(st, write_node(writer, graph, datatype, lang, FIELD_GRAPH, flags));
     }
-	TRY(st, esink("\"", 1, writer));
+    TRY(st, esink("\"", 1, writer));
     /* TRY(st, esink("]\n", 3, writer)); */
     TRY(st, esink("]\n", 2, writer));
     return SERD_SUCCESS;
@@ -1043,12 +1040,11 @@ serd_writer_write_statement(SerdWriter*        writer,
     // Continue a list
     if (!strcmp((const char*)predicate->buf, NS_RDF "first") &&
         !strcmp((const char*)object->buf, NS_RDF "nil")) {
-
-	  if (writer->syntax == SERD_HEXTUPLES) {
-		  return esink("null", 4, writer);
-	  } else {
-		  return esink("()", 2, writer);
-	  }
+      if (writer->syntax == SERD_HEXTUPLES) {
+        return esink("null", 4, writer);
+      } else {
+        return esink("()", 2, writer);
+      }
     }
 
     TRY_FAILING(
@@ -1150,7 +1146,8 @@ serd_writer_end_anon(SerdWriter* writer, const SerdNode* node)
 
   SerdStatus st = SERD_SUCCESS;
 
-  if (writer->syntax == SERD_NTRIPLES || writer->syntax == SERD_NQUADS || writer->syntax == SERD_HEXTUPLES) {
+  if (writer->syntax == SERD_NTRIPLES || writer->syntax == SERD_NQUADS ||
+      writer->syntax == SERD_HEXTUPLES) {
     return SERD_SUCCESS;
   }
 


### PR DESCRIPTION
This adds support for  ndjson hex tuples format explained here: https://github.com/ontola/hextuples an easy to parse ND JSON based RDF representation. It is faster / easier to deal across languages with good JSON support. 