### PR TITLE
Add directional language literal support

### DIFF
--- a/include/serd/serd.h
+++ b/include/serd/serd.h
@@ -80,10 +80,12 @@ typedef enum {
   SERD_TRIG     = 4U, ///< Terse quads http://www.w3.org/TR/trig/
 } SerdSyntax;
 
-/// Flags indicating certain string properties relevant to serialisation
+/// Flags indicating node properties and metadata relevant to serialisation
 typedef enum {
-  SERD_HAS_NEWLINE = 1U << 0U, ///< Contains line breaks ('\\n' or '\\r')
-  SERD_HAS_QUOTE   = 1U << 1U, ///< Contains quotes ('"')
+  SERD_HAS_NEWLINE   = 1U << 0U, ///< Contains line breaks ('\\n' or '\\r')
+  SERD_HAS_QUOTE     = 1U << 1U, ///< Contains quotes ('"')
+  SERD_HAS_DIRECTION = 1U << 2U, ///< Language has a base direction
+  SERD_DIRECTION_RTL = 1U << 3U, ///< Base direction is right-to-left
 } SerdNodeFlag;
 
 /// Bitwise OR of SerdNodeFlag values
@@ -331,7 +333,8 @@ typedef enum {
   /**
      Literal value.
 
-     A literal optionally has either a language, or a datatype (not both).
+     A literal optionally has either a language (possibly with a direction), or
+     a datatype (not both).
   */
   SERD_LITERAL,
 
@@ -572,6 +575,11 @@ typedef SerdStatus (*SerdPrefixSink)(void* SERD_UNSPECIFIED       handle,
    Sink (callback) for statements.
 
    Called for every RDF statement in the serialisation.
+
+   For directional language-tagged literals, `object_lang` contains only the
+   language tag, and has `SERD_HAS_DIRECTION` set.  `SERD_DIRECTION_RTL`
+   selects right-to-left direction, otherwise the direction is left-to-right.
+   The presence of a direction implies the `rdf:dirLangString` datatype.
 */
 typedef SerdStatus (*SerdStatementSink)(
   void* SERD_UNSPECIFIED        handle,
@@ -957,7 +965,10 @@ serd_writer_set_prefix(SerdWriter* SERD_NONNULL     writer,
    Write a statement.
 
    Note this function can be safely casted to SerdStatementSink.
-*/
+
+   For directional language-tagged literals, set `SERD_HAS_DIRECTION` on
+   `lang`, and also set `SERD_DIRECTION_RTL` for right-to-left direction.
+ */
 SERD_API SerdStatus
 serd_writer_write_statement(SerdWriter* SERD_NONNULL      writer,
                             SerdStatementFlags            flags,

--- a/src/n3.c
+++ b/src/n3.c
@@ -531,7 +531,39 @@ read_PN_PREFIX(SerdReader* const reader, const Ref dest, bool* const ate_dot)
 }
 
 static SerdStatus
-read_LANGTAG(SerdReader* const reader, Ref* const dest)
+read_base_direction(SerdReader* const reader, const Ref lang)
+{
+  char   direction[4] = {0, 0, 0, 0};
+  size_t length       = 0U;
+  int    c            = 0;
+
+  while (((c = peek_byte(reader)) > 0) && is_alpha(c)) {
+    if (length < sizeof(direction) - 1U) {
+      direction[length] = (char)c;
+    }
+
+    ++length;
+    skip_byte(reader, c);
+  }
+
+  SerdNode* const node = deref(reader, lang);
+  if (length == 3U && !memcmp(direction, "ltr", 3U)) {
+    node->flags |= SERD_HAS_DIRECTION;
+    return SERD_SUCCESS;
+  }
+
+  if (length == 3U && !memcmp(direction, "rtl", 3U)) {
+    node->flags |= SERD_HAS_DIRECTION | SERD_DIRECTION_RTL;
+    return SERD_SUCCESS;
+  }
+
+  return r_err(reader,
+               SERD_ERR_BAD_SYNTAX,
+               "bad base direction, expected 'ltr' or 'rtl'\n");
+}
+
+static SerdStatus
+read_LANG_DIR(SerdReader* const reader, Ref* const dest)
 {
   int c = peek_byte(reader);
   if (!is_alpha(c)) {
@@ -547,7 +579,17 @@ read_LANGTAG(SerdReader* const reader, Ref* const dest)
   }
 
   while (peek_byte(reader) == '-') {
-    TRY(st, push_byte(reader, *dest, eat_byte_safe(reader, '-')));
+    skip_byte(reader, '-');
+    if (peek_byte(reader) == '-') {
+      skip_byte(reader, '-');
+      return read_base_direction(reader, *dest);
+    }
+
+    TRY(st, push_byte(reader, *dest, '-'));
+    if (!is_alpha(peek_byte(reader)) && !is_digit(peek_byte(reader))) {
+      return r_err(reader, SERD_ERR_BAD_SYNTAX, "expected language subtag\n");
+    }
+
     while (((c = peek_byte(reader)) > 0) && (is_alpha(c) || is_digit(c))) {
       TRY(st, push_byte(reader, *dest, eat_byte_safe(reader, c)));
     }
@@ -779,11 +821,11 @@ read_literal(SerdReader* const    reader,
   const int next = peek_byte(reader);
   if (next == '@') {
     skip_byte(reader, '@');
-    if ((st = read_LANGTAG(reader, lang))) {
+    if ((st = read_LANG_DIR(reader, lang))) {
       *datatype = pop_node(reader, *datatype);
       *lang     = pop_node(reader, *lang);
       *dest     = pop_node(reader, *dest);
-      return r_err(reader, st, "bad language tag\n");
+      return r_err(reader, st, "bad language tag or base direction\n");
     }
   } else if (next == '^') {
     skip_byte(reader, '^');

--- a/src/writer.c
+++ b/src/writer.c
@@ -896,7 +896,11 @@ write_literal(SerdWriter* const     writer,
   }
   if (lang && lang->buf) {
     TRY(st, esink("@", 1, writer));
-    st = esink(lang->buf, lang->n_bytes, writer);
+    TRY(st, esink(lang->buf, lang->n_bytes, writer));
+    if (lang->flags & SERD_HAS_DIRECTION) {
+      st = esink(
+        (lang->flags & SERD_DIRECTION_RTL) ? "--rtl" : "--ltr", 5, writer);
+    }
   } else if (datatype && datatype->buf) {
     TRY(st, esink("^^", 2, writer));
     st = write_iri(writer, datatype);
@@ -1039,6 +1043,9 @@ serd_writer_write_statement(SerdWriter* const     writer,
   assert(predicate);
   assert(object);
 
+  const SerdNodeFlags direction =
+    lang ? lang->flags & (SERD_HAS_DIRECTION | SERD_DIRECTION_RTL) : 0U;
+
   SerdStatus st = SERD_SUCCESS;
 
   if ((flags & SERD_LIST_O_BEGIN) &&
@@ -1053,6 +1060,8 @@ serd_writer_write_statement(SerdWriter* const     writer,
   if (!is_resource(subject) || !is_resource(predicate) ||
       object->type == SERD_NOTHING || !object->buf ||
       (datatype && datatype->buf && lang && lang->buf) ||
+      direction == SERD_DIRECTION_RTL ||
+      (direction && (!lang->buf || object->type != SERD_LITERAL)) ||
       ((flags & SERD_ANON_S_BEGIN) && (flags & SERD_LIST_S_BEGIN)) ||
       ((flags & SERD_EMPTY_S) && (flags & SERD_LIST_S_BEGIN)) ||
       ((flags & SERD_ANON_O_BEGIN) && (flags & SERD_LIST_O_BEGIN)) ||

--- a/test/test_reader.c
+++ b/test/test_reader.c
@@ -25,6 +25,12 @@ typedef struct {
   int n_end;
 } ReaderTest;
 
+typedef struct {
+  const char*   language;
+  SerdNodeFlags direction;
+  int           n_statement;
+} DirectionTest;
+
 static SerdStatus
 base_sink(void* const handle, const SerdNode* const uri)
 {
@@ -68,6 +74,41 @@ statement_sink(void* const           handle,
 
   ReaderTest* const rt = (ReaderTest*)handle;
   ++rt->n_statement;
+  return SERD_SUCCESS;
+}
+
+static SerdStatus
+direction_statement_sink(void* const           handle,
+                         SerdStatementFlags    flags,
+                         const SerdNode* const graph,
+                         const SerdNode* const subject,
+                         const SerdNode* const predicate,
+                         const SerdNode* const object,
+                         const SerdNode* const object_datatype,
+                         const SerdNode* const object_lang)
+{
+  (void)flags;
+  (void)graph;
+  (void)subject;
+  (void)predicate;
+
+  DirectionTest* const test = (DirectionTest*)handle;
+  assert(object->type == SERD_LITERAL);
+  assert(!object_datatype);
+  assert(object_lang);
+  assert(!strcmp((const char*)object_lang->buf, test->language));
+  assert((object_lang->flags & (SERD_HAS_DIRECTION | SERD_DIRECTION_RTL)) ==
+         test->direction);
+
+  ++test->n_statement;
+  return SERD_SUCCESS;
+}
+
+static SerdStatus
+quiet_error_sink(void* const handle, const SerdError* const error)
+{
+  (void)handle;
+  (void)error;
   return SERD_SUCCESS;
 }
 
@@ -120,6 +161,73 @@ test_read_string(void)
   assert(rt.n_end == 0);
 
   serd_reader_free(reader);
+}
+
+static void
+check_directional_literal(const SerdSyntax    syntax,
+                          const char* const   string,
+                          const char* const   language,
+                          const SerdNodeFlags direction,
+                          const SerdStatus    expected_status)
+{
+  DirectionTest     test   = {language, direction, 0};
+  SerdReader* const reader = serd_reader_new(
+    syntax, &test, NULL, NULL, NULL, direction_statement_sink, NULL);
+
+  assert(reader);
+  serd_reader_set_error_sink(reader, quiet_error_sink, NULL);
+
+  const SerdStatus status =
+    serd_reader_read_string(reader, (const uint8_t*)string);
+
+  assert(status == expected_status);
+  assert(test.n_statement == (expected_status ? 0 : 1));
+  serd_reader_free(reader);
+}
+
+static void
+test_directional_literals(void)
+{
+  static const char* const prefix =
+    "<http://example.org/s> <http://example.org/p> ";
+
+  const SerdSyntax syntaxes[] = {SERD_TURTLE, SERD_NTRIPLES};
+  for (size_t i = 0; i < sizeof(syntaxes) / sizeof(syntaxes[0]); ++i) {
+    char string[128] = {0};
+
+    snprintf(string, sizeof(string), "%s\"abc\"@en--ltr .", prefix);
+    check_directional_literal(
+      syntaxes[i], string, "en", SERD_HAS_DIRECTION, SERD_SUCCESS);
+
+    snprintf(string, sizeof(string), "%s\"abc\"@en-US--ltr .", prefix);
+    check_directional_literal(
+      syntaxes[i], string, "en-US", SERD_HAS_DIRECTION, SERD_SUCCESS);
+
+    snprintf(string, sizeof(string), "%s\"abc\"@ar-EG--rtl .", prefix);
+    check_directional_literal(syntaxes[i],
+                              string,
+                              "ar-EG",
+                              SERD_HAS_DIRECTION | SERD_DIRECTION_RTL,
+                              SERD_SUCCESS);
+
+    snprintf(string, sizeof(string), "%s\"abc\"@en-US .", prefix);
+    check_directional_literal(syntaxes[i], string, "en-US", 0U, SERD_SUCCESS);
+
+    const char* const bad_suffixes[] = {
+      "\"abc\"@en--abc .",
+      "\"abc\"@en--LTR .",
+      "\"abc\"@en-- .",
+      "\"abc\"@--rtl .",
+      "\"abc\"@en---rtl .",
+    };
+
+    for (size_t j = 0; j < sizeof(bad_suffixes) / sizeof(bad_suffixes[0]);
+         ++j) {
+      snprintf(string, sizeof(string), "%s%s", prefix, bad_suffixes[j]);
+      check_directional_literal(
+        syntaxes[i], string, "", 0U, SERD_ERR_BAD_SYNTAX);
+    }
+  }
 }
 
 /// Reads a null byte after a statement, then succeeds again (like a socket)
@@ -437,6 +545,7 @@ main(void)
 
   test_null_callbacks();
   test_read_string();
+  test_directional_literals();
   test_read_eof_file(path);
   test_read_eof_by_byte();
   assert(!remove(path));

--- a/test/test_writer.c
+++ b/test/test_writer.c
@@ -47,6 +47,50 @@ test_write_long_literal(void)
 }
 
 static void
+check_write_direction(const SerdSyntax    syntax,
+                      const SerdNodeFlags direction,
+                      const char* const   expected)
+{
+  SerdEnv* const env = serd_env_new(NULL);
+  assert(env);
+
+  SerdChunk         chunk = {NULL, 0};
+  SerdWriter* const writer =
+    serd_writer_new(syntax, (SerdStyle)0U, env, NULL, serd_chunk_sink, &chunk);
+  assert(writer);
+
+  SerdNode s = serd_node_from_string(SERD_URI, USTR(NS_EG "s"));
+  SerdNode p = serd_node_from_string(SERD_URI, USTR(NS_EG "p"));
+  SerdNode o = serd_node_from_string(SERD_LITERAL, USTR("abc"));
+  SerdNode l = serd_node_from_string(SERD_LITERAL, USTR("en"));
+  l.flags |= direction;
+
+  assert(!serd_writer_write_statement(writer, 0, NULL, &s, &p, &o, NULL, &l));
+  assert(!serd_writer_finish(writer));
+
+  uint8_t* const out = serd_chunk_sink_finish(&chunk);
+  assert(expect_string((const char*)out, expected));
+  serd_free(out);
+
+  serd_writer_free(writer);
+  serd_env_free(env);
+}
+
+static void
+test_write_directional_literals(void)
+{
+  check_write_direction(SERD_TURTLE,
+                        SERD_HAS_DIRECTION,
+                        "<http://example.org/s>\n"
+                        "\t<http://example.org/p> \"abc\"@en--ltr .\n");
+
+  check_write_direction(
+    SERD_NTRIPLES,
+    SERD_HAS_DIRECTION | SERD_DIRECTION_RTL,
+    "<http://example.org/s> <http://example.org/p> \"abc\"@en--rtl .\n");
+}
+
+static void
 test_write_nested_anon(void)
 {
   SerdEnv*    env    = serd_env_new(NULL);
@@ -341,6 +385,8 @@ test_write_bad_statement(void)
   SerdNode p = serd_node_from_string(SERD_URI, USTR("http://example.org/p"));
   SerdNode o = serd_node_from_string(SERD_URI, USTR("http://example.org/o"));
   SerdNode l = serd_node_from_string(SERD_LITERAL, USTR("lang"));
+  SerdNode d = l;
+  d.flags |= SERD_DIRECTION_RTL;
 
   assert(serd_writer_write_statement(
            writer,
@@ -383,6 +429,9 @@ test_write_bad_statement(void)
            NULL) == SERD_ERR_BAD_ARG);
 
   assert(serd_writer_write_statement(writer, 0U, NULL, &s, &p, &o, &o, &l) ==
+         SERD_ERR_BAD_ARG);
+
+  assert(serd_writer_write_statement(writer, 0U, NULL, &s, &p, &o, NULL, &d) ==
          SERD_ERR_BAD_ARG);
 
   serd_writer_free(writer);
@@ -466,6 +515,7 @@ int
 main(void)
 {
   test_write_long_literal();
+  test_write_directional_literals();
   test_write_nested_anon();
   test_writer_cleanup();
   test_write_bad_anon_stack();


### PR DESCRIPTION
# Add RDF 1.2 directional language literal support

## Summary

This adds minimal support for RDF 1.2 directional language-tagged strings
(`rdf:dirLangString`) in Turtle, TriG, N-Triples, and N-Quads.

The reader now recognizes `LANG_DIR` forms such as:

```turtle
"Hello"@en--ltr
"مرحبا"@ar--rtl
```

Ordinary language-tagged strings such as `"Hello"@en` continue to use the
existing behavior.

## Implementation

- Add node flags for the presence of a base direction and for selecting `rtl`.
- Keep the language tag in `object_lang->buf` and store the direction in its
  flags, preserving the existing statement sink signature and `SerdNode`
  layout.
- Parse the optional `--ltr` or `--rtl` suffix separately from the language
  tag.
- Reject missing, unknown, or uppercase base directions.
- Serialize directional literals without losing their direction.
- Reject incoherent writer input, such as `rtl` without a direction marker or
  direction metadata on a non-literal object.

This approach preserves ABI compatibility and avoids treating the direction as
part of the BCP 47 language tag.

## Testing

- Added reader coverage for Turtle and N-Triples:
  - `ltr` and `rtl`
  - language subtags
  - ordinary language-tagged literals
  - invalid and missing directions
  - missing language tags and malformed separators
- Added writer coverage for Turtle and N-Triples.
- Verified the complete test suite:

```text
Ok: 41
Expected Fail: 24
Fail: 0
```

Build and test commands:

```sh
meson setup build -Dbuildtype=debug -Dwerror=true
meson compile -C build
meson test -C build --print-errorlogs
```